### PR TITLE
Update sqoop URL to use HTTPS

### DIFF
--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -1,6 +1,8 @@
 on:
   pull_request:
+    branches: [main, master]
   push:
+    branches: [main, master]
   release:
     types: [published]
 

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -1,8 +1,6 @@
 on:
   pull_request:
-    branches: [main, master]
   push:
-    branches: [main, master]
   release:
     types: [published]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 ##### CREATE MAIN HADOOP IMAGE #####
 
 # Fresh base image 
-FROM centos:7 AS hadoop
+FROM centos:7
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 
 # Development tools
@@ -78,9 +78,6 @@ RUN chown -R root:root /etc/docker-config/ && \
 
 
 ##### CREATE MAIN SQOOP IMAGE #####
-
-# Use hadoop image as base 
-FROM hadoop AS sqoop
 
 # Sqoop
 ARG SQOOP_VER=1.4.7

--- a/Dockerfile
+++ b/Dockerfile
@@ -81,7 +81,6 @@ RUN chown -R root:root /etc/docker-config/ && \
 
 # Use hadoop image as base 
 FROM hadoop AS sqoop
-SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 
 # Sqoop
 ARG SQOOP_VER=1.4.7
@@ -89,7 +88,7 @@ ARG SQOOP_HADOOP_VER=2.6.0
 ENV SQOOP_HOME /usr/local/sqoop
 ENV SQOOP_CONF_DIR "$SQOOP_HOME"/conf
 ENV PATH "$PATH":"$HADOOP_HOME"/bin:"$SQOOP_HOME"/bin
-RUN curl -s http://archive.apache.org/dist/sqoop/"$SQOOP_VER"/sqoop-"$SQOOP_VER".bin__hadoop-"$SQOOP_HADOOP_VER".tar.gz \
+RUN curl -s https://archive.apache.org/dist/sqoop/"$SQOOP_VER"/sqoop-"$SQOOP_VER".bin__hadoop-"$SQOOP_HADOOP_VER".tar.gz \
     | tar -xz -C /usr/local && \
     ln -s /usr/local/sqoop-"$SQOOP_VER".bin__hadoop-"$SQOOP_HADOOP_VER" "$SQOOP_HOME"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 ##### CREATE MAIN HADOOP IMAGE #####
 
 # Fresh base image 
-FROM centos:7
+FROM centos:7 AS hadoop
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 
 # Development tools
@@ -32,7 +32,7 @@ ENV HADOOP_MAPRED_HOME "$HADOOP_HOME"
 ENV HADOOP_YARN_HOME "$HADOOP_HOME"
 ENV HADOOP_CONF_DIR "$HADOOP_HOME"/etc/hadoop
 ENV PATH "$PATH":"$HADOOP_HOME"/bin
-RUN curl -sk https://archive.apache.org/dist/hadoop/common/hadoop-"$HADOOP_VER"/hadoop-"$HADOOP_VER".tar.gz \
+RUN curl -s https://archive.apache.org/dist/hadoop/common/hadoop-"$HADOOP_VER"/hadoop-"$HADOOP_VER".tar.gz \
     | tar -xz -C /usr/local/ && \
     cd /usr/local && \
     ln -s ./hadoop-"$HADOOP_VER" hadoop && \
@@ -78,6 +78,10 @@ RUN chown -R root:root /etc/docker-config/ && \
 
 
 ##### CREATE MAIN SQOOP IMAGE #####
+
+# Use hadoop image as base 
+FROM hadoop AS sqoop
+SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 
 # Sqoop
 ARG SQOOP_VER=1.4.7


### PR DESCRIPTION
After 5 years it looks like whoever maintains the Apache attic got around to adding HTTPS. This [temporarily broke our docker builds](https://github.com/ccao-data/service-sqoop-iasworld/actions/runs/8349075666), but [is fixed](https://github.com/ccao-data/service-sqoop-iasworld/actions/runs/8349984201) by simply updating the static sqoop URL.